### PR TITLE
Language

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,1 @@
+indent_size = 2

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -49,6 +49,7 @@ declare const _default: {
     setApiKey: (apiKey?: string | undefined) => void;
     /** run this if you love console logs */
     verbose: () => void;
+    language: "en";
     /**
      * don't use this.
      *

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -9,6 +9,10 @@ export declare const verbose: () => void;
  * you should add an api key to httpClient
  */
 export declare const setApiKey: (apiKey?: string | undefined) => void;
+/**
+ * change the language
+ */
+export declare const setLanguage: (lang: ManifestLanguage) => void;
 /** await this for the current manifest metadata (version, paths) */
 export declare let manifestMetadataPromise: Promise<DestinyManifest>;
 /** you could run this to refresh manifest version, or after adding a api key */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -26,8 +26,7 @@ export declare const fetchManifestMetadata: () => Promise<DestinyManifest>;
 export declare let allManifest: AllDestinyManifestComponents | undefined;
 export declare const setManifest: (manifest: AllDestinyManifestComponents) => void;
 /** stores the manifestVersion that we have cached */
-export declare let storedVersion: string;
-export declare const setStoredVersion: (version: string) => void;
+export declare const setLoadedVersion: (version: string) => void;
 /** which version is actually in the manifest variable */
 export declare let loadedVersion: string;
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,12 @@ let httpClient = generateHttpClient(fetch);
 export const setApiKey = (apiKey) => {
     httpClient = generateHttpClient(fetch, apiKey);
 };
+/**
+ * change the language
+ */
+export const setLanguage = (lang) => {
+    language = lang;
+};
 /** await this for the current manifest metadata (version, paths) */
 export let manifestMetadataPromise;
 /** you could run this to refresh manifest version, or after adding a api key */

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ version in API: "${manifestMetadata.version}"`);
     isVerbose && console.log('getting entire manifest from API');
     allManifest = await getAllDestinyManifestComponents(httpClient, { destinyManifest: manifestMetadata, language });
     isVerbose && console.log(`manifest downloaded. ${Object.keys(allManifest !== null && allManifest !== void 0 ? allManifest : {}).length} components`);
-    loadedVersion = manifestMetadata.version;
+    loadedVersion = `${manifestMetadata.version}__${language}`;
 };
 /** performs a lookup of a known hash */
 export const get = (componentName, hash) => {
@@ -128,6 +128,7 @@ export default {
     setApiKey,
     /** run this if you love console logs */
     verbose,
+    language,
     /**
      * don't use this.
      *

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,9 +48,8 @@ export const setManifest = (manifest) => {
     allManifest = manifest;
 };
 /** stores the manifestVersion that we have cached */
-export let storedVersion = 'no manifest storage method set';
-export const setStoredVersion = (version) => {
-    storedVersion = version;
+export const setLoadedVersion = (version) => {
+    loadedVersion = version;
 };
 /** which version is actually in the manifest variable */
 export let loadedVersion = 'nothing loaded';
@@ -77,7 +76,7 @@ version in API: "${manifestMetadata.version}"`);
     isVerbose && console.log('getting entire manifest from API');
     allManifest = await getAllDestinyManifestComponents(httpClient, { destinyManifest: manifestMetadata, language });
     isVerbose && console.log(`manifest downloaded. ${Object.keys(allManifest !== null && allManifest !== void 0 ? allManifest : {}).length} components`);
-    loadedVersion = `${manifestMetadata.version}__${language}`;
+    setLoadedVersion(`${manifestMetadata.version}__${language}`);
 };
 /** performs a lookup of a known hash */
 export const get = (componentName, hash) => {

--- a/lib/node/index.d.ts
+++ b/lib/node/index.d.ts
@@ -69,5 +69,6 @@ declare const _default: {
      * downloads the manifest file from the internet
      */
     load: () => Promise<void>;
+    setLanguage: (lang: ManifestLanguage) => void;
 };
 export default _default;

--- a/lib/node/index.d.ts
+++ b/lib/node/index.d.ts
@@ -1,7 +1,11 @@
+import { ManifestLanguage } from '../index.js';
 export * from '../index.js';
 export declare const setManifestsPath: (path: string) => void;
 /** check files in the manifestsPath, find the highest numbered one */
-export declare const getLatestCachedVersion: () => string;
+export declare const getLatestCachedVersion: (lang: ManifestLanguage) => {
+    version: string;
+    path: string;
+} | null;
 /**
  * loads a LOCAL manifest file (the most recent available) only. won't update or DL if it's missing
  *

--- a/lib/node/index.d.ts
+++ b/lib/node/index.d.ts
@@ -2,10 +2,7 @@ import { ManifestLanguage } from '../index.js';
 export * from '../index.js';
 export declare const setManifestsPath: (path: string) => void;
 /** check files in the manifestsPath, find the highest numbered one */
-export declare const getLatestCachedVersion: (lang: ManifestLanguage) => {
-    version: string;
-    path: string;
-} | null;
+export declare const getLatestCachedVersion: (lang: ManifestLanguage) => string;
 /**
  * loads a LOCAL manifest file (the most recent available) only. won't update or DL if it's missing
  *

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { allManifest, language, fetchManifestMetadata, find, setLanguage, get, getAll, isVerbose, loadManifestFromApi, loadedVersion, setApiKey, setManifest, verbose, } from '../index.js';
+import { allManifest, language, fetchManifestMetadata, find, setLanguage, get, getAll, isVerbose, loadManifestFromApi, loadedVersion, setApiKey, setManifest, setLoadedVersion, verbose, } from '../index.js';
 import { compareVersionNumbers } from 'destiny2-utils';
 import { sep } from 'path';
 export * from '../index.js';
@@ -21,13 +21,7 @@ export const getLatestCachedVersion = (lang) => {
         .filter((p) => /^[\w.-]+\.json$/)
         .filter((p) => p.includes(languageSuffix))
         .sort(compareVersionNumbers);
-    return manifestsByVersion[0]
-        ? {
-            // trim 83341.20.04.17.1921-8__en.json to 83341.20.04.17.1921-8
-            version: (_a = manifestsByVersion[0]) === null || _a === void 0 ? void 0 : _a.replace(`${languageSuffix}.json`, ''),
-            path: manifestsByVersion[0],
-        }
-        : null;
+    return (_a = manifestsByVersion[0]) === null || _a === void 0 ? void 0 : _a.replace(`.json`, '');
 };
 /**
  * loads a LOCAL manifest file (the most recent available) only. won't update or DL if it's missing
@@ -46,19 +40,18 @@ export const loadLocal = (fromLoad = false) => {
         console.log(`version cached: "${latestCachedVersion}"
 version loaded in memory: "${loadedVersion}"`);
     isVerbose && !latestCachedVersion && console.log('no latest manifest found');
-    if (latestCachedVersion && loadedVersion === (latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version)) {
+    if (latestCachedVersion && loadedVersion === latestCachedVersion) {
         isVerbose && console.log(`latest saved version is already loaded`);
         return true;
     }
     // let's try loading the saved copy
     if (latestCachedVersion) {
-        isVerbose && console.log(`loading latest saved manifest: ${latestCachedVersion.path}`);
+        isVerbose && console.log(`loading latest saved manifest: ${latestCachedVersion}`);
         try {
-            setManifest(JSON.parse(fs.readFileSync(manifestsPath + latestCachedVersion.path, 'utf8')));
+            setManifest(JSON.parse(fs.readFileSync(manifestsPath + latestCachedVersion + '.json', 'utf8')));
             isVerbose && console.log(`manifest loaded from file. ${Object.keys(allManifest !== null && allManifest !== void 0 ? allManifest : {}).length} components`);
             manifestDidLoad = true;
-            // TODO: this is never used?
-            // setStoredVersion(latestCachedVersion);
+            setLoadedVersion(latestCachedVersion);
         }
         catch (e) {
             isVerbose && console.log('manifest failed loading. file missing? malformed?');
@@ -74,18 +67,21 @@ version loaded in memory: "${loadedVersion}"`);
  * downloads the manifest file from the internet
  */
 export const load = async () => {
-    const apiVersion = (await fetchManifestMetadata()).version;
+    const apiVersion = `${(await fetchManifestMetadata()).version}__${language}`;
     const latestCachedVersion = getLatestCachedVersion(language);
     isVerbose &&
-        console.log(`version cached: "${latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.path}"
+        console.log(`version cached: "${latestCachedVersion}"
 version loaded in memory: "${loadedVersion}"
 version in API: "${apiVersion}"`);
     let latestIsLoaded = false;
     // there's nothing to do. why did you run this?
-    if ((latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version) === apiVersion && loadedVersion === (latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version))
+    if (latestCachedVersion === apiVersion && latestCachedVersion === loadedVersion) {
+        isVerbose && console.log('manifest in memory is latest');
         latestIsLoaded = true;
+    }
     // we already have the latest one cached but it's not loaded
-    else if ((latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version) === apiVersion && loadedVersion !== (latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version)) {
+    else if (latestCachedVersion === apiVersion && loadedVersion !== latestCachedVersion) {
+        isVerbose && console.log('loading cached from disk');
         const didLoad = loadLocal(true);
         if (didLoad)
             latestIsLoaded = true;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { allManifest, fetchManifestMetadata, find, get, getAll, isVerbose, loadManifestFromApi, loadedVersion, setApiKey, setManifest, setStoredVersion, verbose, } from '../index.js';
+import { allManifest, language, fetchManifestMetadata, find, get, getAll, isVerbose, loadManifestFromApi, loadedVersion, setApiKey, setManifest, verbose, } from '../index.js';
 import { compareVersionNumbers } from 'destiny2-utils';
 import { sep } from 'path';
 export * from '../index.js';
@@ -12,15 +12,22 @@ const enforceManifestsDir = () => {
         fs.mkdirSync(manifestsPath);
 };
 /** check files in the manifestsPath, find the highest numbered one */
-export const getLatestCachedVersion = () => {
-    var _a, _b;
+export const getLatestCachedVersion = (lang) => {
+    var _a;
     enforceManifestsDir();
+    const languageSuffix = `__${lang}`;
     const manifestsByVersion = fs
         .readdirSync(manifestsPath)
         .filter((p) => /^[\w.-]+\.json$/)
+        .filter((p) => p.includes(languageSuffix))
         .sort(compareVersionNumbers);
-    // trim 83341.20.04.17.1921-8.json to 83341.20.04.17.1921-8
-    return (_b = (_a = manifestsByVersion[0]) === null || _a === void 0 ? void 0 : _a.replace('.json', '')) !== null && _b !== void 0 ? _b : '';
+    return manifestsByVersion[0]
+        ? {
+            // trim 83341.20.04.17.1921-8__en.json to 83341.20.04.17.1921-8
+            version: (_a = manifestsByVersion[0]) === null || _a === void 0 ? void 0 : _a.replace(`${languageSuffix}.json`, ''),
+            path: manifestsByVersion[0],
+        }
+        : null;
 };
 /**
  * loads a LOCAL manifest file (the most recent available) only. won't update or DL if it's missing
@@ -33,24 +40,25 @@ export const getLatestCachedVersion = () => {
  */
 export const loadLocal = (fromLoad = false) => {
     let manifestDidLoad = false;
-    const latestCachedVersion = getLatestCachedVersion();
+    const latestCachedVersion = getLatestCachedVersion(language);
     isVerbose &&
         !fromLoad &&
         console.log(`version cached: "${latestCachedVersion}"
 version loaded in memory: "${loadedVersion}"`);
     isVerbose && !latestCachedVersion && console.log('no latest manifest found');
-    if (latestCachedVersion && loadedVersion === latestCachedVersion) {
+    if (latestCachedVersion && loadedVersion === (latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version)) {
         isVerbose && console.log(`latest saved version is already loaded`);
         return true;
     }
     // let's try loading the saved copy
     if (latestCachedVersion) {
-        isVerbose && console.log(`loading latest saved manifest: ${latestCachedVersion}.json`);
+        isVerbose && console.log(`loading latest saved manifest: ${latestCachedVersion.path}`);
         try {
-            setManifest(JSON.parse(fs.readFileSync(manifestsPath + latestCachedVersion + '.json', 'utf8')));
+            setManifest(JSON.parse(fs.readFileSync(manifestsPath + latestCachedVersion.path, 'utf8')));
             isVerbose && console.log(`manifest loaded from file. ${Object.keys(allManifest !== null && allManifest !== void 0 ? allManifest : {}).length} components`);
             manifestDidLoad = true;
-            setStoredVersion(latestCachedVersion);
+            // TODO: this is never used?
+            // setStoredVersion(latestCachedVersion);
         }
         catch (e) {
             isVerbose && console.log('manifest failed loading. file missing? malformed?');
@@ -67,17 +75,17 @@ version loaded in memory: "${loadedVersion}"`);
  */
 export const load = async () => {
     const apiVersion = (await fetchManifestMetadata()).version;
-    const latestCachedVersion = getLatestCachedVersion();
+    const latestCachedVersion = getLatestCachedVersion(language);
     isVerbose &&
-        console.log(`version cached: "${latestCachedVersion}"
+        console.log(`version cached: "${latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.path}"
 version loaded in memory: "${loadedVersion}"
 version in API: "${apiVersion}"`);
     let latestIsLoaded = false;
     // there's nothing to do. why did you run this?
-    if (latestCachedVersion === apiVersion && loadedVersion === latestCachedVersion)
+    if ((latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version) === apiVersion && loadedVersion === (latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version))
         latestIsLoaded = true;
     // we already have the latest one cached but it's not loaded
-    else if (latestCachedVersion === apiVersion && loadedVersion !== latestCachedVersion) {
+    else if ((latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version) === apiVersion && loadedVersion !== (latestCachedVersion === null || latestCachedVersion === void 0 ? void 0 : latestCachedVersion.version)) {
         const didLoad = loadLocal(true);
         if (didLoad)
             latestIsLoaded = true;
@@ -93,6 +101,7 @@ version in API: "${apiVersion}"`);
 };
 /** saves the loaded manifest to a json file */
 export const save = () => {
+    console.log('HELLO HELLO');
     isVerbose && console.log(`saving manifest to "${manifestsPath + loadedVersion + '.json'}".`);
     fs.writeFileSync(manifestsPath + loadedVersion + '.json', JSON.stringify(allManifest));
     return true;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -101,7 +101,6 @@ version in API: "${apiVersion}"`);
 };
 /** saves the loaded manifest to a json file */
 export const save = () => {
-    console.log('HELLO HELLO');
     isVerbose && console.log(`saving manifest to "${manifestsPath + loadedVersion + '.json'}".`);
     fs.writeFileSync(manifestsPath + loadedVersion + '.json', JSON.stringify(allManifest));
     return true;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { allManifest, language, fetchManifestMetadata, find, get, getAll, isVerbose, loadManifestFromApi, loadedVersion, setApiKey, setManifest, verbose, } from '../index.js';
+import { allManifest, language, fetchManifestMetadata, find, setLanguage, get, getAll, isVerbose, loadManifestFromApi, loadedVersion, setApiKey, setManifest, verbose, } from '../index.js';
 import { compareVersionNumbers } from 'destiny2-utils';
 import { sep } from 'path';
 export * from '../index.js';
@@ -150,4 +150,5 @@ export default {
      * downloads the manifest file from the internet
      */
     load,
+    setLanguage,
 };

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -10,7 +10,7 @@ import {
   loadedVersion,
   setApiKey,
   setManifest,
-  setStoredVersion,
+  setLoadedVersion,
   verbose,
 } from '../index.js';
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -10,7 +10,6 @@ import {
   loadedVersion,
   setApiKey,
   setManifest,
-  setLoadedVersion,
   verbose,
 } from '../index.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,9 @@ export type ManifestLanguage =
   | 'ko'
   | 'zh-cht'
   | 'zh-chs';
-export let language: ManifestLanguage = 'en';
 
 export let isVerbose = false;
+
 /** run this if you love console logs */
 export const verbose = () => {
   isVerbose = true;
@@ -51,8 +51,10 @@ export const setApiKey = (apiKey?: string) => {
   httpClient = generateHttpClient(fetch, apiKey);
 };
 
+export let language: ManifestLanguage = 'en';
+
 /**
- * change the language
+ * sets the language of the manifest to download
  */
 export const setLanguage = (lang: ManifestLanguage) => {
   language = lang;
@@ -81,11 +83,6 @@ export const setManifest = (manifest: AllDestinyManifestComponents) => {
   allManifest = manifest;
 };
 
-/** stores the manifestVersion that we have cached */
-export const setLoadedVersion = (version: string) => {
-  loadedVersion = version;
-};
-
 /** which version is actually in the manifest variable */
 export let loadedVersion = 'nothing loaded';
 
@@ -101,20 +98,23 @@ let downloadsInProgress: Promise<any>[] = [];
  */
 export const loadManifestFromApi = async (forceUpdate = false) => {
   const manifestMetadata = await fetchManifestMetadata();
+  const apiVersion = `${manifestMetadata.version}__${language}`;
+
   isVerbose &&
     !forceUpdate &&
     console.log(`version loaded in memory: "${loadedVersion}"
-version in API: "${manifestMetadata.version}"`);
+version in API: "${apiVersion}"`);
 
   // we're done if the API version already matches the one we have loaded
-  if (!forceUpdate && loadedVersion === manifestMetadata.version) {
+  if (!forceUpdate && loadedVersion === apiVersion) {
     isVerbose && console.log('loaded manifest is already up to date');
     return;
   }
   isVerbose && console.log('getting entire manifest from API');
   allManifest = await getAllDestinyManifestComponents(httpClient, { destinyManifest: manifestMetadata, language });
   isVerbose && console.log(`manifest downloaded. ${Object.keys(allManifest ?? {}).length} components`);
-  setLoadedVersion(`${manifestMetadata.version}__${language}`);
+
+  loadedVersion = apiVersion;
 };
 
 /** performs a lookup of a known hash */
@@ -183,10 +183,10 @@ export default {
    * you should add an api key to httpClient
    */
   setApiKey,
+
   /** run this if you love console logs */
   verbose,
 
-  language,
   /**
    * don't use this.
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,13 @@ export const setApiKey = (apiKey?: string) => {
   httpClient = generateHttpClient(fetch, apiKey);
 };
 
+/**
+ * change the language
+ */
+export const setLanguage = (lang: ManifestLanguage) => {
+  language = lang;
+};
+
 /** await this for the current manifest metadata (version, paths) */
 export let manifestMetadataPromise: Promise<DestinyManifest>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ version in API: "${manifestMetadata.version}"`);
   isVerbose && console.log('getting entire manifest from API');
   allManifest = await getAllDestinyManifestComponents(httpClient, { destinyManifest: manifestMetadata, language });
   isVerbose && console.log(`manifest downloaded. ${Object.keys(allManifest ?? {}).length} components`);
-  loadedVersion = manifestMetadata.version;
+  loadedVersion = `${manifestMetadata.version}__${language}`;
 };
 
 /** performs a lookup of a known hash */
@@ -133,7 +133,7 @@ export const getAll = <K extends DestinyManifestComponentName>(
 
 /** returns a manifest component (a set of definitions keyed by hash number) */
 export const getComponent = <K extends DestinyManifestComponentName>(
-  componentName: K
+  componentName: K,
 ): AllDestinyManifestComponents[K] => {
   if (!allManifest) throw Error('manifest accessed before being loaded');
   return allManifest?.[componentName];
@@ -179,6 +179,8 @@ export default {
   setApiKey,
   /** run this if you love console logs */
   verbose,
+
+  language,
   /**
    * don't use this.
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,9 +82,8 @@ export const setManifest = (manifest: AllDestinyManifestComponents) => {
 };
 
 /** stores the manifestVersion that we have cached */
-export let storedVersion = 'no manifest storage method set';
-export const setStoredVersion = (version: string) => {
-  storedVersion = version;
+export const setLoadedVersion = (version: string) => {
+  loadedVersion = version;
 };
 
 /** which version is actually in the manifest variable */
@@ -115,7 +114,7 @@ version in API: "${manifestMetadata.version}"`);
   isVerbose && console.log('getting entire manifest from API');
   allManifest = await getAllDestinyManifestComponents(httpClient, { destinyManifest: manifestMetadata, language });
   isVerbose && console.log(`manifest downloaded. ${Object.keys(allManifest ?? {}).length} components`);
-  loadedVersion = `${manifestMetadata.version}__${language}`;
+  setLoadedVersion(`${manifestMetadata.version}__${language}`);
 };
 
 /** performs a lookup of a known hash */

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -10,10 +10,8 @@ import {
   getAll,
   isVerbose,
   loadManifestFromApi,
-  loadedVersion,
   setApiKey,
   setManifest,
-  setLoadedVersion,
   verbose,
   ManifestLanguage,
 } from '../index.js';
@@ -22,6 +20,8 @@ import { compareVersionNumbers } from 'destiny2-utils';
 import { sep } from 'path';
 
 export * from '../index.js';
+
+let loadedVersion = 'not loaded';
 
 let manifestsPath = `.${sep}manifests${sep}`;
 export const setManifestsPath = (path: string) => {
@@ -80,7 +80,7 @@ version loaded in memory: "${loadedVersion}"`);
       isVerbose && console.log(`manifest loaded from file. ${Object.keys(allManifest ?? {}).length} components`);
       manifestDidLoad = true;
 
-      setLoadedVersion(latestCachedVersion);
+      loadedVersion = latestCachedVersion;
     } catch (e) {
       isVerbose && console.log('manifest failed loading. file missing? malformed?');
       console.log(e);
@@ -111,6 +111,7 @@ version in API: "${apiVersion}"`);
     isVerbose && console.log('manifest in memory is latest');
     latestIsLoaded = true;
   }
+
   // we already have the latest one cached but it's not loaded
   else if (latestCachedVersion === apiVersion && loadedVersion !== latestCachedVersion) {
     isVerbose && console.log('loading cached from disk');
@@ -122,6 +123,9 @@ version in API: "${apiVersion}"`);
     isVerbose && console.log(`loading from cache failed or wasn't attempted. starting download.`);
     // dispatch a force download
     await loadManifestFromApi(true);
+
+    loadedVersion = apiVersion;
+
     // save the results for next time
     save();
   }
@@ -178,5 +182,9 @@ export default {
    * downloads the manifest file from the internet
    */
   load,
+
+  /**
+   * sets the language of the manifest to download
+   */
   setLanguage,
 };

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -5,6 +5,7 @@ import {
   language,
   fetchManifestMetadata,
   find,
+  setLanguage,
   get,
   getAll,
   isVerbose,
@@ -178,4 +179,5 @@ export default {
    * downloads the manifest file from the internet
    */
   load,
+  setLanguage,
 };

--- a/test/test.ts
+++ b/test/test.ts
@@ -7,16 +7,20 @@ manifest.verbose();
   await manifest.load();
   console.log('manifest should be loaded');
 
-  console.log('getting kindled orchid by hash');
+  console.log('\nloading manifest again, this should use the memory cache');
+  await manifest.load();
+  console.log('manifest should be loaded');
+
+  console.log('\ngetting kindled orchid by hash');
   console.log(manifest.get('DestinyInventoryItemDefinition', 2575506895)?.displayProperties);
 
-  console.log('finding Primeval Prime by name');
+  console.log('\nfinding Primeval Prime by name');
   console.log(manifest.find('DestinyInventoryItemDefinition', 'Primeval Prime')?.[0]?.displayProperties);
 
-  console.log('switching to french');
+  console.log('\nswitching to french');
   manifest.setLanguage('fr');
   await manifest.load();
 
-  console.log('getting kindled orchid by hash, but french');
+  console.log('\ngetting kindled orchid by hash, but french');
   console.log(manifest.get('DestinyInventoryItemDefinition', 2575506895)?.displayProperties);
 })();

--- a/test/test.ts
+++ b/test/test.ts
@@ -12,4 +12,11 @@ manifest.verbose();
 
   console.log('finding Primeval Prime by name');
   console.log(manifest.find('DestinyInventoryItemDefinition', 'Primeval Prime')?.[0]?.displayProperties);
+
+  console.log('switching to french');
+  manifest.setLanguage('fr');
+  await manifest.load();
+
+  console.log('getting kindled orchid by hash, but french');
+  console.log(manifest.get('DestinyInventoryItemDefinition', 2575506895)?.displayProperties);
 })();


### PR DESCRIPTION
Adds the ability to change the definitions language requested. 

Change summary:

 - index.ts exports `setLanguage`
 - definitions are saved to disk as `83341.20.04.17.1921-8__en.json`
 - fixes a bug where previously in-memory definitions would not be used if they were loaded from disk (`loadedVersion` was only set after the API call)

TODO:
 - [ ] Browser support